### PR TITLE
Added compeletion that includes current operation.

### DIFF
--- a/src/main/groovy/com/budjb/asynchronoustasks/AbstractAsynchronousTask.groovy
+++ b/src/main/groovy/com/budjb/asynchronoustasks/AbstractAsynchronousTask.groovy
@@ -163,9 +163,24 @@ abstract class AbstractAsynchronousTask implements AsynchronousTask {
     /**
      * Completes the task.
      *
+     * @param currentOperation Description of the current operation the task is performing.
+     */
+    abstract protected void complete(String currentOperation)
+
+    /**
+     * Completes the task.
+     *
      * @param results
      */
     abstract protected void complete(Object results)
+
+    /**
+     * Completes the task.
+     *
+     * @param currentOperation Description of the current operation the task is performing.
+     * @param results
+     */
+    abstract protected void complete(String currentOperation, Object results)
 
     /**
      * Does the actual work of the task.


### PR DESCRIPTION
Due to the ```complete(Object)``` signature, I could not have a ```complete(String)``` signature.

In the **PersistentAsynchronousTask** class, I had to preserve ```currentStatus``` in the event that ```null``` gets passed; I am not sure if this is appropriate or not, so suggestions welcome.

Once again, tests pass locally.